### PR TITLE
Adding changes to support mongo ordered/unordered bulk operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ to Mongoose models to ensure schema validation and any schema defaults are appli
 
 **toObjectConfig**: Configuration to pass to the `toObject` method when converting Mongoose models back to plain items, safe for insertion into the bulk operation. Default value is `{depopulate: true, versionKey: false}`.
 
+**Ordered**: Specifies if the bulk operation should be ordered or unordered. Default value is `true`.
+
 ## Migrating from 1.x to 2.x
 Plugin configuration is now passed as a single object via the `upsertMany` key in your schema options. If you used the `upsertMatchFields` setting, you need to replace this with:
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = function upsertMany(schema) {
       depopulate: true,
       versionKey: false,
     },
+    ordered: true,
   }, schema.options.upsertMany || {});
 
   //Create helper
@@ -80,7 +81,10 @@ module.exports = function upsertMany(schema) {
         }
       });
 
+    //Retrieve if bulkWrite should be a ordered or unordered write
+    let {ordered} = config;
+
     //Bulk write
-    return this.bulkWrite(ops);
+    return this.bulkWrite(ops, {ordered});
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meanie/mongoose-upsert-many",
   "description": "A plugin that adds an upsertMany bulk op to Mongoose schemas",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "homepage": "https://github.com/meanie/mongoose-upsert-many",
   "author": {
     "name": "Adam Reis",


### PR DESCRIPTION
Adding changes to support the ability to have unordered bulk operations.

Leveraging as per below:
https://docs.mongodb.com/manual/core/bulk-write-operations/